### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/src/web/flask_app.py
+++ b/src/web/flask_app.py
@@ -17,7 +17,7 @@ def get_secret(secret_name, project_id):
         response = client.access_secret_version(request={"name": name})
         return response.payload.data.decode("UTF-8")
     except Exception as e:
-        logger.error(f"Error accessing secret {secret_name}: {str(e)}")
+        logger.error(f"Error accessing secret: {str(e)}")
         return os.getenv(secret_name.upper(), "")  # Fallback to environment variable
 
 def create_app():


### PR DESCRIPTION
Potential fix for [https://github.com/Drakovthe5th/crptgameminer/security/code-scanning/1](https://github.com/Drakovthe5th/crptgameminer/security/code-scanning/1)

To fix the problem, we should avoid logging the value of `secret_name` in the error message. Instead, we can log a generic error message indicating that there was an error accessing a secret, without specifying which one. If necessary for debugging, we can log the exception message alone, but we should ensure that it does not contain sensitive information. The change should be made only to the error logging line in the `get_secret` function (line 20 in `src/web/flask_app.py`). No additional imports or method definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging by removing sensitive information from log messages when accessing secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->